### PR TITLE
Integration of cloud event SDK

### DIFF
--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -22,7 +22,6 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     apple_rules_dependencies()
     upb_bazel_version_repository(name = "upb_bazel_version")
     antlr_dependencies(471)
-    boost_deps()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",
@@ -55,3 +54,4 @@ def envoy_dependency_imports(go_version = GO_VERSION):
 
     config_validation_pip_install()
     protodoc_pip_install()
+    boost_deps()

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -8,6 +8,7 @@ load("@upb//bazel:repository_defs.bzl", upb_bazel_version_repository = "bazel_ve
 load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install = "pip_install")
 load("@protodoc_pip3//:requirements.bzl", protodoc_pip_install = "pip_install")
 load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
+load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 
 # go version for rules_go
 GO_VERSION = "1.14.7"
@@ -21,6 +22,7 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     apple_rules_dependencies()
     upb_bazel_version_repository(name = "upb_bazel_version")
     antlr_dependencies(471)
+    boost_deps()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -9,6 +9,7 @@ load("@config_validation_pip3//:requirements.bzl", config_validation_pip_install
 load("@protodoc_pip3//:requirements.bzl", protodoc_pip_install = "pip_install")
 load("@rules_antlr//antlr:deps.bzl", "antlr_dependencies")
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
+load("@org_cloudabi_bazel_third_party//:third_party.bzl", "third_party_repositories")
 
 # go version for rules_go
 GO_VERSION = "1.14.7"
@@ -55,3 +56,4 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     config_validation_pip_install()
     protodoc_pip_install()
     boost_deps()
+    third_party_repositories()

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -22,6 +22,7 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     apple_rules_dependencies()
     upb_bazel_version_repository(name = "upb_bazel_version")
     antlr_dependencies(471)
+    boost_deps()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -22,7 +22,6 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     apple_rules_dependencies()
     upb_bazel_version_repository(name = "upb_bazel_version")
     antlr_dependencies(471)
-    boost_deps()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -199,6 +199,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_libevent_libevent()
     _com_github_luajit_luajit()
     _com_github_moonjit_moonjit()
+    _com_github_nelhage_rules_boost()
     _com_github_nghttp2_nghttp2()
     _com_github_nodejs_http_parser()
     _com_github_tencent_rapidjson()
@@ -422,6 +423,9 @@ cc_library(
         patches = ["@envoy//bazel:antlr.patch"],
         **location
     )
+
+def _com_github_nelhage_rules_boost():
+    _repository_impl("com_github_nelhage_rules_boost")
 
 def _com_github_nghttp2_nghttp2():
     location = _get_location("com_github_nghttp2_nghttp2")

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -184,6 +184,7 @@ def envoy_dependencies(skip_targets = []):
     # dependencies and name conflicts.
     _com_github_c_ares_c_ares()
     _com_github_circonus_labs_libcircllhist()
+    _com_github_cloudevents_sdk()
     _com_github_cyan4973_xxhash()
     _com_github_datadog_dd_opentracing_cpp()
     _com_github_mirror_tclap()
@@ -202,6 +203,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_nelhage_rules_boost()
     _com_github_nghttp2_nghttp2()
     _com_github_nodejs_http_parser()
+    _com_github_rules_proto_grpc()
     _com_github_tencent_rapidjson()
     _com_google_absl()
     _com_google_googletest()
@@ -226,6 +228,7 @@ def envoy_dependencies(skip_targets = []):
     _repository_impl("bazel_compdb")
     _repository_impl("envoy_build_tools")
     _repository_impl("rules_cc")
+    _org_cloudabi_bazel_third_party()
     _org_unicode_icuuc()
 
     # Unconditional, since we use this only for compiler-agnostic fuzzing utils.
@@ -289,6 +292,9 @@ def _com_github_c_ares_c_ares():
         name = "ares",
         actual = "@envoy//bazel/foreign_cc:ares",
     )
+
+def _com_github_cloudevents_sdk():
+    _repository_impl("com_github_cloudevents_sdk")
 
 def _com_github_cyan4973_xxhash():
     _repository_impl(
@@ -474,6 +480,11 @@ def _com_github_datadog_dd_opentracing_cpp():
         name = "dd_opentracing_cpp",
         actual = "@com_github_datadog_dd_opentracing_cpp//:dd_opentracing_cpp",
     )
+
+def _com_github_rules_proto_grpc():
+    # Require rules proto grpc as an indirect dependency as it is needed by the
+    # direct dependency com_github_cloudevents_sdk.
+    _repository_impl("rules_proto_grpc")
 
 def _com_github_tencent_rapidjson():
     _repository_impl(
@@ -923,6 +934,9 @@ filegroup(
         build_file_content = BUILD_ALL_CONTENT,
         **_get_location("kafka_python_client")
     )
+
+def _org_cloudabi_bazel_third_party():
+    _repository_impl("org_cloudabi_bazel_third_party")
 
 def _org_unicode_icuuc():
     _repository_impl(

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -259,6 +259,16 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
         use_category = ["dataplane"],
         cpe = "N/A",
     ),
+    com_github_nelhage_rules_boost = dict(
+        project_name = "Nelhage",
+        project_url = "https://github.com/nelhage/rules_boost",
+        version = "1e3a69bf2d5cd10c34b74f066054cd335d033d71",
+        sha256 = "b3cbdceaa95b8cfe3a69ff37f8ad0e53a77937433234f6b9a6add2eff5bde333",
+        strip_prefix = "rules_boost-1e3a69bf2d5cd10c34b74f066054cd335d033d71",
+        urls = ["https://github.com/nelhage/rules_boost/archive/1e3a69bf2d5cd10c34b74f066054cd335d033d71.tar.gz"],
+        use_category = ["dataplane"],
+        cpe = "N/A",
+    ),
     com_github_nghttp2_nghttp2 = dict(
         project_name = "Nghttp2",
         project_url = "https://nghttp2.org",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -156,6 +156,17 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
         use_category = ["observability"],
         cpe = "N/A",
     ),
+    com_github_cloudevents_sdk = dict(
+        project_name = "Cloudevents SDK",
+        project_url = "https://github.com/googleinterns/cloudevents-sdk-cpp",
+        version = "d9d133fb19430d9896345b4189f35b94a0cf990c",
+        sha256 = "23ff0f3ee649eb1dcf84a126abf2280385cc416cc4eaf67fab6ebd5d892f2966",
+        strip_prefix = "cloudevents-sdk-cpp-{version}",
+        # 2020-09-07
+        urls = ["https://github.com/googleinterns/cloudevents-sdk-cpp/archive/{version}.tar.gz"],
+        use_category = ["dataplane"],
+        cpe = "N/A",
+    ),
     com_github_cyan4973_xxhash = dict(
         project_name = "xxHash",
         project_url = "https://github.com/Cyan4973/xxHash",
@@ -670,6 +681,17 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
         urls = ["https://github.com/dpkp/kafka-python/archive/{version}.tar.gz"],
         use_category = ["test"],
     ),
+    org_cloudabi_bazel_third_party = dict(
+        project_name = "Cloudabi bazel third party",
+        project_url = "https://github.com/NuxiNL/bazel-third-party",
+        version = "91ca2167219c612a89334fa09ddf15fbdc5d0592",
+        sha256 = "639ac8f97673dcde752f02bc4744409bc68cb1556972946d7818e7a17e141e50",
+        strip_prefix = "bazel-third-party-91ca2167219c612a89334fa09ddf15fbdc5d0592",
+        # 2020-08-15
+        urls = ["https://github.com/NuxiNL/bazel-third-party/archive/91ca2167219c612a89334fa09ddf15fbdc5d0592.tar.gz"],
+        use_category = ["dataplane"],
+        cpe = "N/A",
+    ),
     org_unicode_icuuc = dict(
         project_name = "International Components for Unicode",
         project_url = "https://github.com/unicode-org/icu",
@@ -712,6 +734,16 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
         strip_prefix = "emsdk-{version}",
         urls = ["https://github.com/emscripten-core/emsdk/archive/{version}.tar.gz"],
         use_category = ["build"],
+    ),
+    rules_proto_grpc = dict(
+        project_name = "Rules proto grpc",
+        project_url = "https://github.com/rules-proto-grpc/rules_proto_grpc",
+        version = "1.0.2",
+        sha256 = "5f0f2fc0199810c65a2de148a52ba0aff14d631d4e8202f41aff6a9d590a471b",
+        strip_prefix = "rules_proto_grpc-1.0.2",
+        urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/1.0.2.tar.gz"],
+        use_category = ["dataplane"],
+        cpe = "N/A",
     ),
     rules_antlr = dict(
         project_name = "ANTLR Rules for Bazel",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -157,7 +157,7 @@ DEPENDENCY_REPOSITORIES_SPEC = dict(
         cpe = "N/A",
     ),
     com_github_cloudevents_sdk = dict(
-        project_name = "Cloudevents SDK",
+        project_name = "CloudEvents SDK",
         project_url = "https://github.com/googleinterns/cloudevents-sdk-cpp",
         version = "d9d133fb19430d9896345b4189f35b94a0cf990c",
         sha256 = "23ff0f3ee649eb1dcf84a126abf2280385cc416cc4eaf67fab6ebd5d892f2966",

--- a/source/extensions/filters/http/gcp_events_convert/BUILD
+++ b/source/extensions/filters/http/gcp_events_convert/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         "//source/common/stats:symbol_table_lib",
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
+        "@boost//:beast",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/gcp_events_convert/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/gcp_events_convert/BUILD
+++ b/source/extensions/filters/http/gcp_events_convert/BUILD
@@ -27,6 +27,8 @@ envoy_cc_library(
         "//source/extensions/filters/http:well_known_names",
         "//source/extensions/filters/http/common:pass_through_filter_lib",
         "@boost//:beast",
+        "@com_github_cloudevents_sdk//v1/protocol_binding:http_binder_lib",
+        "@com_github_cloudevents_sdk//v1/protocol_binding:pubsub_binder_lib",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_proto",
         "@envoy_api//envoy/extensions/filters/http/gcp_events_convert/v3:pkg_cc_proto",
     ],

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -124,19 +124,19 @@ bool GcpEventsConvertFilter::isCloudEvent(const Http::RequestHeaderMap& headers)
 }
 
 absl::Status GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
-  for (auto it = http_req.base().begin(); it != http_req.base().end(); ++it) {
-    Http::LowerCaseString header_key((*it).name_string().to_string());
-    std::string header_val = (*it).value().to_string();
+  for (const auto& header : http_req.base()) {
+    Http::LowerCaseString header_key(header.name_string().to_string());
+    // std::string header_val = header.value().to_string();
     if (header_key == Http::LowerCaseString("content-type")) {
-      request_headers_->setContentType(header_val);
+      request_headers_->setContentType(header.value().to_string());
     } else {
-      request_headers_->addCopy(header_key, header_val);
+      request_headers_->addCopy(header_key, header.value().to_string());
     }
   }
   return absl::OkStatus();
 }
 
-absl::Status GcpEventsConvertFilter::updateBody(HttpRequest& http_req) {
+absl::Status GcpEventsConvertFilter::updateBody(const HttpRequest& http_req) {
   decoder_callbacks_->modifyDecodingBuffer([&http_req](Buffer::Instance& buffered) {
     // drain the current buffered instance
     buffered.drain(buffered.length());

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -86,7 +86,7 @@ Http::FilterDataStatus GcpEventsConvertFilter::decodeData(Buffer::Instance&, boo
     return Http::FilterDataStatus::Continue;
   }
 
-  // TODO(#6): Use Cloud Event SDK to convert Pubsub Message to HTTP Binding
+  // TODO(#2): Step 5 & 6 Use Cloud Event SDK to convert Pubsub Message to HTTP Binding
   // HttpRequest http_req = Binder.bind(cloudevents);
   HttpRequest http_req;
   http_req.base().set("content-type", "application/text");

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -86,7 +86,7 @@ Http::FilterDataStatus GcpEventsConvertFilter::decodeData(Buffer::Instance&, boo
     return Http::FilterDataStatus::Continue;
   }
 
-  // TODO(#3): Use Cloud Event SDK to convert Pubsub Message to HTTP Binding
+  // TODO(#6): Use Cloud Event SDK to convert Pubsub Message to HTTP Binding
   // HttpRequest http_req = Binder.bind(cloudevents);
   HttpRequest http_req;
   http_req.base().set("content-type", "application/text");
@@ -124,7 +124,6 @@ bool GcpEventsConvertFilter::isCloudEvent(const Http::RequestHeaderMap& headers)
 }
 
 absl::Status GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
-  // TODO(#3): implement detail logic for update Header
   for (auto it = http_req.base().begin(); it != http_req.base().end(); ++it) {
     Http::LowerCaseString header_key((*it).name_string().to_string());
     std::string header_val = (*it).value().to_string();

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -126,7 +126,6 @@ bool GcpEventsConvertFilter::isCloudEvent(const Http::RequestHeaderMap& headers)
 absl::Status GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
   for (const auto& header : http_req.base()) {
     Http::LowerCaseString header_key(header.name_string().to_string());
-    // std::string header_val = header.value().to_string();
     if (header_key == Http::LowerCaseString("content-type")) {
       request_headers_->setContentType(header.value().to_string());
     } else {

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -86,14 +86,22 @@ Http::FilterDataStatus GcpEventsConvertFilter::decodeData(Buffer::Instance&, boo
     return Http::FilterDataStatus::Continue;
   }
 
-  // TODO(#2): step 5 & 6 Use Cloud Event SDK to convert Pubsub Message to HTTP Binding
-  absl::Status update_status = updateHeader();
+  // TODO(#3): Use Cloud Event SDK to convert Pubsub Message to HTTP Binding
+  // HttpRequest http_req = Binder.bind(cloudevents);
+  HttpRequest http_req;
+  http_req.base().set("content-type", "application/text");
+  http_req.base().set("ce-specversion", "1.0");
+  http_req.base().set("ce-type", "com.example.some_event");
+  http_req.base().set("ce-time", "2020-03-10T03:56:24Z");
+  http_req.body() = "certain body string text";
+
+  absl::Status update_status = updateHeader(http_req);
   if (!update_status.ok()) {
     ENVOY_LOG(warn, "Gcp Events Convert Filter log: update header {}", update_status.ToString());
     return Http::FilterDataStatus::Continue;
   }
 
-  update_status = updateBody();
+  update_status = updateBody(http_req);
   if (!update_status.ok()) {
     ENVOY_LOG(warn, "Gcp Events Convert Filter log: update body {}", update_status.ToString());
     return Http::FilterDataStatus::Continue;
@@ -115,18 +123,26 @@ bool GcpEventsConvertFilter::isCloudEvent(const Http::RequestHeaderMap& headers)
   return headers.getContentTypeValue() == config_->content_type_;
 }
 
-absl::Status GcpEventsConvertFilter::updateHeader() {
+absl::Status GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
   // TODO(#3): implement detail logic for update Header
+  for (auto it = http_req.base().begin(); it != http_req.base().end(); ++it) {
+    Http::LowerCaseString header_key((*it).name_string().to_string());
+    std::string header_val = (*it).value().to_string();
+    if (header_key == Http::LowerCaseString("content-type")) {
+      request_headers_->setContentType(header_val);
+    } else {
+      request_headers_->addCopy(header_key, header_val);
+    }
+  }
   return absl::OkStatus();
 }
 
-absl::Status GcpEventsConvertFilter::updateBody() {
-  decoder_callbacks_->modifyDecodingBuffer([](Buffer::Instance& buffered) {
-    // TODO(#4): implement detail logic for update Body
+absl::Status GcpEventsConvertFilter::updateBody(HttpRequest& http_req) {
+  decoder_callbacks_->modifyDecodingBuffer([&http_req](Buffer::Instance& buffered) {
     // drain the current buffered instance
     buffered.drain(buffered.length());
     // replace the current buffered instance with the new body
-    buffered.add("This is a example body");
+    buffered.add(http_req.body());
   });
   return absl::OkStatus();
 }

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -126,8 +126,9 @@ bool GcpEventsConvertFilter::isCloudEvent(const Http::RequestHeaderMap& headers)
 absl::Status GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
   for (const auto& header : http_req.base()) {
     Http::LowerCaseString header_key(header.name_string().to_string());
-    std::string str = header.value().to_string();
-    absl::string_view header_val(str);
+    // avoid deep copy from boost string_view to absl string_view
+    // only copy the @pointer data() , @length size()
+    absl::string_view header_val(header.value().data(), header.value().size());
     if (header_key == Http::LowerCaseString("content-type")) {
       request_headers_->setContentType(header.value().to_string());
     } else {

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -33,9 +33,11 @@ GcpEventsConvertFilterConfig::GcpEventsConvertFilterConfig(
 GcpEventsConvertFilter::GcpEventsConvertFilter(GcpEventsConvertFilterConfigSharedPtr config)
     : config_(config) {}
 
+// special constructor for Unit Test ONLY
 GcpEventsConvertFilter::GcpEventsConvertFilter(GcpEventsConvertFilterConfigSharedPtr config,
-                                               bool has_cloud_event)
-    : has_cloud_event_(has_cloud_event), config_(config) {}
+                                               bool has_cloud_event,
+                                               Http::RequestHeaderMap* headers)
+    : request_headers_(headers), has_cloud_event_(has_cloud_event), config_(config) {}
 
 void GcpEventsConvertFilter::onDestroy() {}
 

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -126,10 +126,12 @@ bool GcpEventsConvertFilter::isCloudEvent(const Http::RequestHeaderMap& headers)
 absl::Status GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
   for (const auto& header : http_req.base()) {
     Http::LowerCaseString header_key(header.name_string().to_string());
+    std::string str = header.value().to_string();
+    absl::string_view header_val(str);
     if (header_key == Http::LowerCaseString("content-type")) {
-      request_headers_->setContentType(header.value().to_string());
+      request_headers_->setContentType(header_val);
     } else {
-      request_headers_->addCopy(header_key, header.value().to_string());
+      request_headers_->addCopy(header_key, header_val);
     }
   }
   return absl::OkStatus();

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -129,9 +129,9 @@ absl::Status GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
     std::string str = header.value().to_string();
     absl::string_view header_val(str);
     if (header_key == Http::LowerCaseString("content-type")) {
-      request_headers_->setContentType(header_val);
+      request_headers_->setContentType(header.value().to_string());
     } else {
-      request_headers_->addCopy(header_key, header_val);
+      request_headers_->addCopy(header_key, header.value().to_string());
     }
   }
   return absl::OkStatus();

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -130,9 +130,9 @@ absl::Status GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
     // only copy the @pointer data() , @length size()
     absl::string_view header_val(header.value().data(), header.value().size());
     if (header_key == Http::LowerCaseString("content-type")) {
-      request_headers_->setContentType(header.value().to_string());
+      request_headers_->setContentType(header_val);
     } else {
-      request_headers_->addCopy(header_key, header.value().to_string());
+      request_headers_->addCopy(header_key, header_val);
     }
   }
   return absl::OkStatus();

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -14,8 +14,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GcpEventsConvert {
 
-typedef boost::beast::http::request<boost::beast::http::string_body> HttpRequest;
-
 struct GcpEventsConvertFilterConfig : public Router::RouteSpecificFilterConfig {
   GcpEventsConvertFilterConfig(
       const envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert&
@@ -47,6 +45,8 @@ public:
   void setDecoderFilterCallbacks(Http::StreamDecoderFilterCallbacks& callbacks) override;
 
 private:
+  using HttpRequest = boost::beast::http::request<boost::beast::http::string_body>;
+  
   bool isCloudEvent(const Http::RequestHeaderMap& headers) const;
 
   // modify the data of HTTP request

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -46,7 +46,7 @@ public:
 
 private:
   using HttpRequest = boost::beast::http::request<boost::beast::http::string_body>;
-  
+
   bool isCloudEvent(const Http::RequestHeaderMap& headers) const;
 
   // modify the data of HTTP request

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -54,13 +54,13 @@ private:
   // modify the data of HTTP request
   // 1. drain buffered data
   // 2. write cloud event data
-  absl::Status updateBody(const HttpRequest& request);
+  void updateBody(const HttpRequest& request);
 
   // modify the header of HTTP request
   // 1. replace header's content type with ce-datacontenttype
   // 2. add cloud event information, ce-version, ce-type...... (except ce's data)
   // 3. [TBD] add Ack ID into header
-  absl::Status updateHeader(const HttpRequest& request);
+  void updateHeader(const HttpRequest& request);
 
   Http::RequestHeaderMap* request_headers_ = nullptr;
   bool has_cloud_event_ = false;

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -52,7 +52,7 @@ private:
   // modify the data of HTTP request
   // 1. drain buffered data
   // 2. write cloud event data
-  absl::Status updateBody(HttpRequest& request);
+  absl::Status updateBody(const HttpRequest& request);
 
   // modify the header of HTTP request
   // 1. replace header's content type with ce-datacontenttype

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/beast/http.hpp>
 #include <memory>
 #include <string>
 
@@ -12,6 +13,8 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace GcpEventsConvert {
+
+typedef boost::beast::http::request<boost::beast::http::string_body> HttpRequest;
 
 struct GcpEventsConvertFilterConfig : public Router::RouteSpecificFilterConfig {
   GcpEventsConvertFilterConfig(

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -52,13 +52,13 @@ private:
   // modify the data of HTTP request
   // 1. drain buffered data
   // 2. write cloud event data
-  absl::Status updateBody();
+  absl::Status updateBody(HttpRequest& request);
 
   // modify the header of HTTP request
   // 1. replace header's content type with ce-datacontenttype
   // 2. add cloud event information, ce-version, ce-type...... (except ce's data)
   // 3. [TBD] add Ack ID into header
-  absl::Status updateHeader();
+  absl::Status updateHeader(const HttpRequest& request);
 
   Http::RequestHeaderMap* request_headers_ = nullptr;
   bool has_cloud_event_ = false;

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -14,6 +14,8 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GcpEventsConvert {
 
+typedef boost::beast::http::request<boost::beast::http::string_body> HttpRequest;
+
 struct GcpEventsConvertFilterConfig : public Router::RouteSpecificFilterConfig {
   GcpEventsConvertFilterConfig(
       const envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert&

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -14,8 +14,6 @@ namespace Extensions {
 namespace HttpFilters {
 namespace GcpEventsConvert {
 
-typedef boost::beast::http::request<boost::beast::http::string_body> HttpRequest;
-
 struct GcpEventsConvertFilterConfig : public Router::RouteSpecificFilterConfig {
   GcpEventsConvertFilterConfig(
       const envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert&
@@ -48,7 +46,6 @@ public:
 
 private:
   using HttpRequest = boost::beast::http::request<boost::beast::http::string_body>;
-
   bool isCloudEvent(const Http::RequestHeaderMap& headers) const;
 
   // modify the data of HTTP request

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -32,8 +32,10 @@ class GcpEventsConvertFilter : public Http::StreamDecoderFilter,
 public:
   // normal constructor
   GcpEventsConvertFilter(GcpEventsConvertFilterConfigSharedPtr config);
-  // special constructor only used for TEST purpose
-  GcpEventsConvertFilter(GcpEventsConvertFilterConfigSharedPtr config, bool has_cloud_event);
+  // special constructor for Unit Test ONLY
+  GcpEventsConvertFilter(GcpEventsConvertFilterConfigSharedPtr config, 
+                         bool has_cloud_event,
+                         Http::RequestHeaderMap* headers);
   // Http::StreamFilterBase
   void onDestroy() override;
 
@@ -46,6 +48,7 @@ public:
 
 private:
   using HttpRequest = boost::beast::http::request<boost::beast::http::string_body>;
+
   bool isCloudEvent(const Http::RequestHeaderMap& headers) const;
 
   // modify the data of HTTP request

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
@@ -93,10 +93,10 @@ TEST_P(GcpEventsConvertIntegrationTest, CloudEventNormalRequest) {
   ASSERT_TRUE(request_stream->waitForEndStream(*dispatcher_));
   response->waitForEndStream();
   // filter should replace body with given string
-  EXPECT_EQ("certain body string text", request_stream->body().toString());
+  EXPECT_EQ("cloud event data payload", request_stream->body().toString());
   auto& request_headers = request_stream->headers();
   // filter should replace headers content-type with `ce-datecontenttype`
-  EXPECT_EQ("application/text", request_headers.getContentTypeValue());
+  EXPECT_EQ("application/text; charset=utf-8", request_headers.getContentTypeValue());
   // filter should insert ce attribute into header (except for `ce-datacontenttype`)
   EXPECT_THAT(request_headers.get(Http::LowerCaseString("ce-datacontenttype")), testing::IsNull());
   EXPECT_EQ("1.0",
@@ -105,6 +105,10 @@ TEST_P(GcpEventsConvertIntegrationTest, CloudEventNormalRequest) {
             request_headers.get(Http::LowerCaseString("ce-type"))->value().getStringView());
   EXPECT_EQ("2020-03-10T03:56:24Z",
             request_headers.get(Http::LowerCaseString("ce-time"))->value().getStringView());
+  EXPECT_EQ("1234-1234-1234",
+            request_headers.get(Http::LowerCaseString("ce-id"))->value().getStringView());
+  EXPECT_EQ("/mycontext/subcontext",
+            request_headers.get(Http::LowerCaseString("ce-source"))->value().getStringView());
   codec_client->close();
 }
 

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
@@ -93,7 +93,7 @@ TEST_P(GcpEventsConvertIntegrationTest, CloudEventNormalRequest) {
   ASSERT_TRUE(request_stream->waitForEndStream(*dispatcher_));
   response->waitForEndStream();
   // filter should replace body with given string
-  EXPECT_EQ(request_stream->body().toString(), "certain body string text");
+  EXPECT_EQ("certain body string text", request_stream->body().toString());
   auto& request_headers = request_stream->headers();
   // filter should replace headers content-type with `ce-datecontenttype`
   EXPECT_EQ("application/text", request_headers.getContentTypeValue());

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
@@ -93,7 +93,19 @@ TEST_P(GcpEventsConvertIntegrationTest, CloudEventNormalRequest) {
   ASSERT_TRUE(request_stream->waitForEndStream(*dispatcher_));
   response->waitForEndStream();
   // filter should replace body with given string
-  EXPECT_EQ(request_stream->body().toString(), "This is a example body");
+  EXPECT_EQ(request_stream->body().toString(), "certain body string text");
+  auto& request_headers = request_stream->headers();
+  // filter should replace headers content-type with `ce-datecontenttype`
+  EXPECT_EQ("application/text", request_headers.getContentTypeValue());
+  // filter should insert ce attribute into header (except for `ce-datacontenttype`)
+  EXPECT_THAT(request_headers.get(Http::LowerCaseString("ce-datacontenttype")), testing::IsNull());
+  EXPECT_EQ("1.0",
+            request_headers.get(Http::LowerCaseString("ce-specversion"))->value().getStringView());
+  EXPECT_EQ("com.example.some_event",
+            request_headers.get(Http::LowerCaseString("ce-type"))->value().getStringView());
+  EXPECT_EQ("2020-03-10T03:56:24Z",
+            request_headers.get(Http::LowerCaseString("ce-time"))->value().getStringView());
+
   codec_client->close();
 }
 

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
@@ -105,7 +105,6 @@ TEST_P(GcpEventsConvertIntegrationTest, CloudEventNormalRequest) {
             request_headers.get(Http::LowerCaseString("ce-type"))->value().getStringView());
   EXPECT_EQ("2020-03-10T03:56:24Z",
             request_headers.get(Http::LowerCaseString("ce-time"))->value().getStringView());
-
   codec_client->close();
 }
 

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
@@ -126,9 +126,9 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter.decodeData(data, true));
 
   // filter should replace body with given string
-  EXPECT_EQ("certain body string text", buffer.toString());
+  EXPECT_EQ("cloud event data payload", buffer.toString());
   // filter should replace headers content-type with `ce-datecontenttype`
-  EXPECT_EQ("application/text", headers.getContentTypeValue());
+  EXPECT_EQ("application/text; charset=utf-8", headers.getContentTypeValue());
   // filter should insert ce attribute into header (except for `ce-datacontenttype`)
   EXPECT_THAT(headers.get(Http::LowerCaseString("ce-datacontenttype")), testing::IsNull());
   EXPECT_EQ("1.0",
@@ -137,6 +137,10 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
             headers.get(Http::LowerCaseString("ce-type"))->value().getStringView());
   EXPECT_EQ("2020-03-10T03:56:24Z",
             headers.get(Http::LowerCaseString("ce-time"))->value().getStringView());
+  EXPECT_EQ("1234-1234-1234",
+            headers.get(Http::LowerCaseString("ce-id"))->value().getStringView());
+  EXPECT_EQ("/mycontext/subcontext",
+            headers.get(Http::LowerCaseString("ce-source"))->value().getStringView());
 }
 
 TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithRandomBody) {

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
@@ -62,8 +62,10 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeHeaderWithRandomContent) {
 TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEvent) {
   envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert proto_config;
   proto_config.set_content_type("application/grpc+cloudevent+json");
+  Http::TestRequestHeaderMapImpl headers;
   GcpEventsConvertFilter filter(std::make_shared<GcpEventsConvertFilterConfig>(proto_config),
-                                /*has_cloud_event=*/true);
+                                /*has_cloud_event=*/true,
+                                &headers);
   Http::MockStreamDecoderFilterCallbacks callbacks;
   filter.setDecoderFilterCallbacks(callbacks);
 
@@ -79,8 +81,10 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEvent) {
 TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
   envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert proto_config;
   proto_config.set_content_type("application/grpc+cloudevent+json");
+  Http::TestRequestHeaderMapImpl headers;
   GcpEventsConvertFilter filter(std::make_shared<GcpEventsConvertFilterConfig>(proto_config),
-                                /*has_cloud_event=*/true);
+                                /*has_cloud_event=*/true,
+                                &headers);
   Http::MockStreamDecoderFilterCallbacks callbacks;
   filter.setDecoderFilterCallbacks(callbacks);
 
@@ -121,14 +125,26 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
   Buffer::OwnedImpl data;
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter.decodeData(data, true));
 
-  EXPECT_EQ(buffer.toString(), "certain body string text");
+  // filter should replace body with given string
+  EXPECT_EQ("certain body string text", buffer.toString());
+  // filter should replace headers content-type with `ce-datecontenttype`
+  EXPECT_EQ("application/text", headers.getContentTypeValue());
+  // filter should insert ce attribute into header (except for `ce-datacontenttype`)
+  EXPECT_THAT(headers.get(Http::LowerCaseString("ce-datacontenttype")), testing::IsNull());
+  EXPECT_EQ("1.0",
+            headers.get(Http::LowerCaseString("ce-specversion"))->value().getStringView());
+  EXPECT_EQ("com.example.some_event",
+            headers.get(Http::LowerCaseString("ce-type"))->value().getStringView());
+  EXPECT_EQ("2020-03-10T03:56:24Z",
+            headers.get(Http::LowerCaseString("ce-time"))->value().getStringView());
 }
 
 TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithRandomBody) {
   envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert proto_config;
   proto_config.set_content_type("application/grpc+cloudevent+json");
   GcpEventsConvertFilter filter(std::make_shared<GcpEventsConvertFilterConfig>(proto_config),
-                                /*has_cloud_event=*/false);
+                                /*has_cloud_event=*/false,
+                                /*headers=*/nullptr);
   Http::MockStreamDecoderFilterCallbacks callbacks;
   filter.setDecoderFilterCallbacks(callbacks);
 

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
@@ -122,7 +122,7 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
   Buffer::OwnedImpl data;
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter.decodeData(data, true));
 
-  EXPECT_EQ(buffer.toString(), "This is a example body");
+  EXPECT_EQ(buffer.toString(), "certain body string text");
 }
 
 TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithRandomBody) {

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
@@ -76,7 +76,6 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEvent) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter.decodeData(data, false));
 }
 
-
 TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
   envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert proto_config;
   proto_config.set_content_type("application/grpc+cloudevent+json");


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

[CHANGE](https://github.com/YaronKoller/envoy/pull/10/files/6a4d8cb8f9ad3def8f1148d9c0249a5387d06252..0145be228eaa29e1a56a25413727e6d9019c1573) since last PR #12  

[Note] Current PR is based on the two assumption. 
1. receiving a ReceivedMessage in Json format. 
2. The last piece of body will always be buffered. 

They will be fixed in the incoming PR. 


Commit Message: Integrate SDK in to envoy. Using SDK to bind & unbind cloud event. 
Additional Description: Basically wrap things up for filter's functionality. 
Risk Level: Low
Testing: Unit Test & Integration Test
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
