### PR TITLE
Update logic to fix issues found in testing gRPC unary call

### DIFF
--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.cc
@@ -152,11 +152,11 @@ void GcpEventsConvertFilter::updateHeader(const HttpRequest& http_req) {
 }
 
 void GcpEventsConvertFilter::updateBody(const HttpRequest& http_req,
-                                        const Buffer::Instance* bufferedPtr,
+                                        const Buffer::Instance* buffered_ptr,
                                         Buffer::Instance& buffer) {
   // drain the current buffer instance
   buffer.drain(buffer.length());
-  if (bufferedPtr) {
+  if (buffered_ptr) {
     // replace buffered instance with http result from SDK
     decoder_callbacks_->modifyDecodingBuffer([&http_req](Buffer::Instance& buffered) {
       // drain the buffered instance

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -49,12 +49,17 @@ public:
 private:
   using HttpRequest = boost::beast::http::request<boost::beast::http::string_body>;
 
+  // build body with both buffered data and the incoming buffer data
+  std::string buildBody(const Buffer::Instance* buffered, const Buffer::Instance& last);
+
   bool isCloudEvent(const Http::RequestHeaderMap& headers) const;
 
   // modify the data of HTTP request
   // 1. drain buffered data
   // 2. write cloud event data
-  void updateBody(const HttpRequest& request);
+  void updateBody(const HttpRequest& http_req,
+                  const Buffer::Instance* bufferedPtr,
+                  Buffer::Instance& buffer);
 
   // modify the header of HTTP request
   // 1. replace header's content type with ce-datacontenttype

--- a/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
+++ b/source/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter.h
@@ -57,14 +57,11 @@ private:
   // modify the data of HTTP request
   // 1. drain buffered data
   // 2. write cloud event data
-  void updateBody(const HttpRequest& http_req,
-                  const Buffer::Instance* bufferedPtr,
-                  Buffer::Instance& buffer);
+  void updateBody(const HttpRequest& http_req, Buffer::Instance& buffer);
 
   // modify the header of HTTP request
   // 1. replace header's content type with ce-datacontenttype
   // 2. add cloud event information, ce-version, ce-type...... (except ce's data)
-  // 3. [TBD] add Ack ID into header
   void updateHeader(const HttpRequest& request);
 
   Http::RequestHeaderMap* request_headers_ = nullptr;

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_integration_test.cc
@@ -73,18 +73,18 @@ TEST_P(GcpEventsConvertIntegrationTest, CloudEventNormalRequest) {
   attributes["ce-datacontenttype"] = "application/text; charset=utf-8";
   pubsub_message.set_data("cloud event data payload");
 
-  // create a json string of received message
-  std::string json_string;
-  auto status = Envoy::ProtobufUtil::MessageToJsonString(received_message, &json_string);
-  ASSERT_TRUE(status.ok());
+  // create a proto string of received message
+  std::string proto_string;
+  bool status = received_message.SerializeToString(&proto_string);
+  ASSERT_TRUE(status);
 
-  // send json string in multilple bodies @end_stream = false
-  for (size_t index = 0; index < json_string.size(); index += 10) {
-    size_t length = (json_string.size() - index) < 10 ? (json_string.size() - index) : 10;
-    Buffer::OwnedImpl data(json_string.substr(index, length));
+  // send proto string in multilple bodies @end_stream = false
+  for (size_t index = 0; index < proto_string.size(); index += 10) {
+    size_t length = (proto_string.size() - index) < 10 ? (proto_string.size() - index) : 10;
+    Buffer::OwnedImpl data(proto_string.substr(index, length));
     codec_client->sendData(*request_encoder_, data, false);
   }
-  // send the last piece of json string   @end_stream = true
+  // send the last piece of proto string  @end_stream = true
   Buffer::OwnedImpl data;
   codec_client->sendData(*request_encoder_, data, true);
 
@@ -145,22 +145,22 @@ TEST_P(GcpEventsConvertIntegrationTest, CloudEventPartialMissingRequest) {
   attributes["ce-datacontenttype"] = "application/text; charset=utf-8";
   pubsub_message.set_data("cloud event data payload");
 
-  // create a json string of received message
-  std::string full_json_string;
-  auto status = Envoy::ProtobufUtil::MessageToJsonString(received_message, &full_json_string);
-  ASSERT_TRUE(status.ok());
+  // create a proto string of received message
+  std::string full_proto_string;
+  bool status = received_message.SerializeToString(&full_proto_string);
+  ASSERT_TRUE(status);
 
   // another string missing the last 10 characters
-  std::string partial_json_string = full_json_string.substr(0, full_json_string.size() - 10);
+  std::string partial_proto_string = full_proto_string.substr(0, full_proto_string.size() - 10);
 
-  // send json string in multilple bodies @end_stream = false
-  for (size_t index = 0; index < partial_json_string.size(); index += 10) {
+  // send proto string in multilple bodies @end_stream = false
+  for (size_t index = 0; index < partial_proto_string.size(); index += 10) {
     size_t length =
-        (partial_json_string.size() - index) < 10 ? (partial_json_string.size() - index) : 10;
-    Buffer::OwnedImpl data(partial_json_string.substr(index, length));
+        (partial_proto_string.size() - index) < 10 ? (partial_proto_string.size() - index) : 10;
+    Buffer::OwnedImpl data(partial_proto_string.substr(index, length));
     codec_client->sendData(*request_encoder_, data, false);
   }
-  // send the last piece of json string   @end_stream = true
+  // send the last piece of proto string  @end_stream = true
   Buffer::OwnedImpl data;
   codec_client->sendData(*request_encoder_, data, true);
 
@@ -168,8 +168,8 @@ TEST_P(GcpEventsConvertIntegrationTest, CloudEventPartialMissingRequest) {
   ASSERT_TRUE(fake_upstream_connection->waitForNewStream(*dispatcher_, request_stream));
   ASSERT_TRUE(request_stream->waitForEndStream(*dispatcher_));
   response->waitForEndStream();
-  // filter should be pass through since filter can not convert partial json string to proto object
-  EXPECT_EQ(request_stream->body().toString(), partial_json_string);
+  // filter should be pass through since filter can not convert partial proto string to proto object
+  EXPECT_EQ(request_stream->body().toString(), partial_proto_string);
   codec_client->close();
 }
 

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
@@ -90,7 +90,7 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
 
   // buffer simulate the buffered data and will be set manually
   Buffer::OwnedImpl buffer;
-  EXPECT_CALL(callbacks, decodingBuffer).Times(1).WillOnce(testing::Return(&buffer));
+  EXPECT_CALL(callbacks, decodingBuffer).Times(2).WillRepeatedly(testing::Return(&buffer));
   EXPECT_CALL(callbacks, modifyDecodingBuffer)
       .Times(1)
       .WillOnce([&buffer](std::function<void(Buffer::Instance&)> callback) {
@@ -153,7 +153,7 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventOnePiece) {
   Http::MockStreamDecoderFilterCallbacks callbacks;
   filter.setDecoderFilterCallbacks(callbacks);
 
-  EXPECT_CALL(callbacks, decodingBuffer).Times(1).WillOnce(testing::Return(nullptr));
+  EXPECT_CALL(callbacks, decodingBuffer).Times(2).WillRepeatedly(testing::Return(nullptr));
   EXPECT_CALL(callbacks, modifyDecodingBuffer).Times(0);
 
   // create a received message proto object

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
@@ -114,13 +114,13 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
   attributes["ce-datacontenttype"] = "application/text; charset=utf-8";
   pubsub_message.set_data("cloud event data payload");
 
-  // create a json string of received message
-  std::string json_string;
-  auto status = Envoy::ProtobufUtil::MessageToJsonString(received_message, &json_string);
-  ASSERT_TRUE(status.ok());
+  // create a proto string of received message
+  std::string proto_string;
+  bool status = received_message.SerializeToString(&proto_string);
+  ASSERT_TRUE(status);
 
   // Previously stored data
-  buffer.add(json_string);
+  buffer.add(proto_string);
 
   Buffer::OwnedImpl data;
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter.decodeData(data, true));

--- a/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
+++ b/test/extensions/filters/http/gcp_events_convert/gcp_events_convert_filter_test.cc
@@ -143,6 +143,60 @@ TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventEndOfStream) {
             headers.get(Http::LowerCaseString("ce-source"))->value().getStringView());
 }
 
+TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithCloudEventOnePiece) {
+  envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert proto_config;
+  proto_config.set_content_type("application/grpc+cloudevent+json");
+  Http::TestRequestHeaderMapImpl headers;
+  GcpEventsConvertFilter filter(std::make_shared<GcpEventsConvertFilterConfig>(proto_config),
+                                /*has_cloud_event=*/true,
+                                &headers);
+  Http::MockStreamDecoderFilterCallbacks callbacks;
+  filter.setDecoderFilterCallbacks(callbacks);
+
+  EXPECT_CALL(callbacks, decodingBuffer).Times(1).WillOnce(testing::Return(nullptr));
+  EXPECT_CALL(callbacks, modifyDecodingBuffer).Times(0);
+
+  // create a received message proto object
+  ReceivedMessage received_message;
+  received_message.set_ack_id("random ack id");
+  received_message.set_delivery_attempt(3);
+  PubsubMessage& pubsub_message = *received_message.mutable_message();
+  google::protobuf::Map<std::string, std::string>& attributes =
+      *pubsub_message.mutable_attributes();
+  attributes["ce-specversion"] = "1.0";
+  attributes["ce-type"] = "com.example.some_event";
+  attributes["ce-time"] = "2020-03-10T03:56:24Z";
+  attributes["ce-id"] = "1234-1234-1234";
+  attributes["ce-source"] = "/mycontext/subcontext";
+  attributes["ce-datacontenttype"] = "application/text; charset=utf-8";
+  pubsub_message.set_data("cloud event data payload");
+
+  // create a proto string of received message
+  std::string proto_string;
+  bool status = received_message.SerializeToString(&proto_string);
+  ASSERT_TRUE(status);
+
+  Buffer::OwnedImpl data(proto_string);
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter.decodeData(data, true));
+
+  // filter should replace body with given string
+  EXPECT_EQ("cloud event data payload", data.toString());
+  // filter should replace headers content-type with `ce-datecontenttype`
+  EXPECT_EQ("application/text; charset=utf-8", headers.getContentTypeValue());
+  // filter should insert ce attribute into header (except for `ce-datacontenttype`)
+  EXPECT_THAT(headers.get(Http::LowerCaseString("ce-datacontenttype")), testing::IsNull());
+  EXPECT_EQ("1.0",
+            headers.get(Http::LowerCaseString("ce-specversion"))->value().getStringView());
+  EXPECT_EQ("com.example.some_event",
+            headers.get(Http::LowerCaseString("ce-type"))->value().getStringView());
+  EXPECT_EQ("2020-03-10T03:56:24Z",
+            headers.get(Http::LowerCaseString("ce-time"))->value().getStringView());
+  EXPECT_EQ("1234-1234-1234",
+            headers.get(Http::LowerCaseString("ce-id"))->value().getStringView());
+  EXPECT_EQ("/mycontext/subcontext",
+            headers.get(Http::LowerCaseString("ce-source"))->value().getStringView());
+}
+
 TEST(GcpEventsConvertFilterUnitTest, DecodeDataWithRandomBody) {
   envoy::extensions::filters::http::gcp_events_convert::v3::GcpEventsConvert proto_config;
   proto_config.set_content_type("application/grpc+cloudevent+json");


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

[CHANGE](https://github.com/YaronKoller/envoy/pull/17/files/52a568ddf0e57416f9960099b2f698e5f559a9e8) since you last review

The previous version are based on three untested assumptions:

    1. unary gRPC may only have one buffer and it's also the end of that HTTP request. -> decodeData @buffer != empty @end_stream = true
    2. unary gRPC is anther transport layer build above HTTP 2.0, the payload of HTTP 2.0 is the gRPC frame + object in proto format instead of json
    3. gRPC reverse bridge will not transfer proto format to json format

Commit Message: Fix issues found in real world testing. Solve problems related to three untested assumptions. 
Additional Description: Solutions to solve three aforementioned assumptions. 

    1. using ParseFromString instead of JsonToMessage
    2. allow buffered pointer to be nullptr
    3. update body will prioritize to update buffered data. If nullptr, will update current buffer data.

Risk Level: Low
Testing: Unit Test and Integration Test
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
